### PR TITLE
Basic navigation for workshop pages

### DIFF
--- a/ICLR2020_workshop.md
+++ b/ICLR2020_workshop.md
@@ -6,6 +6,16 @@ description: 'ICLR 2020 Workshop: Tackling Climate Change with Machine Learning'
 
 <h1>ICLR 2020 Workshop <br> Tackling Climate Change with Machine Learning</h1>
 
+<div class='buttons'>
+  <a class='button' href='#about-iclr'>About</a>
+  <a class='button' href='#keynote-speakers'>Speakers</a>
+  <a class='button' href='#schedule'>Schedule</a>
+  <a class='button' href='#organizers'>Organizers</a>
+  <a class='button' href='#accepted-works'>Accepted Works</a>
+  <a class='button' href='#call-for-submissions'>Call for Submissions</a>
+  <a class='button' href='#frequently-asked-questions'>FAQ</a>
+</div>
+
 ***
 
 <center> <h3>Announcements</h3> </center>

--- a/ICML2019_workshop.md
+++ b/ICML2019_workshop.md
@@ -6,6 +6,16 @@ description: 'ICML 2019 Workshop: Climate Change: How Can AI Help?'
 
 <h1>ICML 2019 Workshop <br>Climate Change: How Can AI Help?</h1>
 
+<div class='buttons'>
+  <a class='button' href='#about-the-workshop'>About</a>
+  <a class='button' href='#speakers'>Speakers</a>
+  <a class='button' href='#schedule'>Schedule</a>
+  <a class='button' href='#organizers'>Organizers</a>
+  <a class='button' href='#research-track'>Accepted Works</a>
+  <a class='button' href='#call-for-submissions'>Call for Submissions</a>
+  <a class='button' href='#frequently-asked-questions'>FAQ</a>
+</div>
+
 ***
 
 <center> <h3>Announcements</h3> </center>

--- a/NeurIPS2019_workshop.md
+++ b/NeurIPS2019_workshop.md
@@ -6,6 +6,16 @@ description: 'NeurIPS 2019 Workshop: Tackling Climate Change with Machine Learni
 
 <h1>NeurIPS 2019 Workshop <br> Tackling Climate Change with Machine Learning</h1>
 
+<div class='buttons'>
+  <a class='button' href='#about-the-workshop'>About</a>
+  <a class='button' href='#invited-speakers'>Speakers</a>
+  <a class='button' href='#schedule'>Schedule</a>
+  <a class='button' href='#organizers'>Organizers</a>
+  <a class='button' href='#accepted-works'>Accepted Works</a>
+  <a class='button' href='#call-for-submissions'>Call for Submissions</a>
+  <a class='button' href='#frequently-asked-questions'>FAQ</a>
+</div>
+
 ***
 
 <center> <h3>Announcements</h3> </center>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -337,3 +337,21 @@ summary {
 details[open] summary {
   margin-bottom: 1rem;
 }
+
+// Ensure that anchor links don't skip the headers
+@media screen and (min-width: 1024px) {
+  h1::before, h2::before {
+    content: "";
+    display: block;
+    height: 80px; /* fixed header height*/
+    margin: -80px 0 0; /* negative fixed header height */
+  }
+}
+@media screen and (max-width: 1023px) {
+  h1::before, h2::before {
+    content: "";
+    display: block;
+    height: 68px; /* fixed header height*/
+    margin: -68px 0 0; /* negative fixed header height */
+  }
+}


### PR DESCRIPTION
This is super basic, but probably an improvement:

![image](https://user-images.githubusercontent.com/1022564/79042785-9fa09b80-7bc8-11ea-817e-454231a355b1.png)

I tried a few fancier things with [hero units](https://bulma.io/documentation/layout/hero/#gradients) but it didn't look nice. I also added the same subnav for NeurIPS and ICML 2019 (AMLD2020 and COP25 didn't have enough content to justify it).