### PR TITLE
Version 2 of role display

### DIFF
--- a/about.md
+++ b/about.md
@@ -25,9 +25,7 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
 * To promote discourse about best practices regarding the use of machine learning in climate change domains.
 
 # People
-
-## Steering Committee
-
+## CCAI Chairs
 <div class="person__list">
 <a class="person__item" href="http://www.davidrolnick.com" target="_blank">
   <div class="person__pic-wrapper">
@@ -35,7 +33,7 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
   </div>
   <div class="person__name">David Rolnick</div>
   <div class="person__affil">University of Pennsylvania</div>
-  <div class="person__title">Chair</div>
+  
 </a>
 
 <a class="person__item" href="https://priyadonti.com/" target="_blank">
@@ -44,7 +42,7 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
   </div>
   <div class="person__name">Priya L. Donti</div>
   <div class="person__affil">Carnegie Mellon</div>
-  <div class="person__title">Chair</div>
+  
 </a>
 
 <a class="person__item" href="https://epg.ethz.ch/people/senior-researchers/dr--lynn-kaack.html" target="_blank">
@@ -53,43 +51,18 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
   </div>
   <div class="person__name">Lynn H. Kaack</div>
   <div class="person__affil">ETH Zürich</div>
-  <div class="person__title">Chair</div>
+  
 </a>
-
-<a class="person__item" href="https://mila.quebec/en/person/kris-sankaran/" target="_blank">
-  <div class="person__pic-wrapper">
-    <img class="person__pic" src="images/people/krissankaran_200x200.jpg">
-  </div>
-  <div class="person__name">Kris Sankaran</div>
-  <div class="person__affil">Mila, U. de Montréal</div>
-  <div class="person__title">Partnerships</div>
-</a>
-
+</div>
+## Content Committee
+<div class="person__list">
 <a class="person__item" href="https://www.sashaluccioni.com/" target="_blank">
   <div class="person__pic-wrapper">
     <img class="person__pic" src="images/people/sashaluccioni_200x200.jpg">
   </div>
   <div class="person__name">Sasha Luccioni</div>
   <div class="person__affil">Mila, U. de Montréal</div>
-  <div class="person__title">Partnerships</div>
-</a>
-
-<a class="person__item" href="https://asross.github.io/" target="_blank">
-  <div class="person__pic-wrapper">
-    <img class="person__pic" src="images/people/andrew_ross_200x200.jpg">
-  </div>
-  <div class="person__name">Andrew Slavin Ross</div>
-  <div class="person__affil">Harvard University</div>
-  <div class="person__title">Website</div>
-</a>
-
-<a class="person__item" href="http://www.kochanski.org/kelly/" target="_blank">
-  <div class="person__pic-wrapper">
-    <img class="person__pic" src="images/people/kellykochanski_200x200.jpg">
-  </div>
-  <div class="person__name">Kelly Kochanski</div>
-  <div class="person__affil">CU Boulder</div>
-  <div class="person__title"></div>
+  <div class="person__title">Committee Chair</div>
 </a>
 
 <a class="person__item" href="https://scholar.google.com/citations?user=71a2-WMAAAAJ&hl=en" target="_blank">
@@ -98,34 +71,7 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
   </div>
   <div class="person__name">Alexandre Lacoste</div>
   <div class="person__affil">Element AI</div>
-  <div class="person__title"></div>
-</a>
-
-<a class="person__item" href="https://www.mcc-berlin.net/en/about/team/milojevic-dupont-nikola.html" target="_blank">
-  <div class="person__pic-wrapper">
-    <img class="person__pic" src="images/people/nikolamilojevicdupont_200x200.jpg">
-  </div>
-  <div class="person__name">Nikola Milojevic-Dupont</div>
-  <div class="person__affil">MCC Berlin, TU Berlin</div>
-  <div class="person__title"></div>
-</a>
-
-<a class="person__item" href="https://www.media.mit.edu/people/jaquesn/overview/" target="_blank">
-  <div class="person__pic-wrapper">
-    <img class="person__pic" src="images/people/natashajaques_200x200.jpg">
-  </div>
-  <div class="person__name">Natasha Jaques</div>
-  <div class="person__affil">MIT</div>
-  <div class="person__title"></div>
-</a>
-
-<a class="person__item" href="http://www.teganmaharaj.com" target="_blank">
-  <div class="person__pic-wrapper">
-    <img class="person__pic" src="images/people/teganmaharaj_200x200.jpg">
-  </div>
-  <div class="person__name">Tegan Maharaj</div>
-  <div class="person__affil">Mila, Polytechnique Montréal</div>
-  <div class="person__title"></div>
+  <div class="person__title">Datasets Lead</div>
 </a>
 
 <a class="person__item" href="https://www.evansherwin.com/" target="_blank">
@@ -134,7 +80,74 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
   </div>
   <div class="person__name">Evan D. Sherwin</div>
   <div class="person__affil">Stanford University</div>
-  <div class="person__title"></div>
+  <div class="person__title">Meetups Lead</div>
+</a>
+</div>
+## Communications Committee
+<div class="person__list">
+<a class="person__item" href="https://mila.quebec/en/person/kris-sankaran/" target="_blank">
+  <div class="person__pic-wrapper">
+    <img class="person__pic" src="images/people/krissankaran_200x200.jpg">
+  </div>
+  <div class="person__name">Kris Sankaran</div>
+  <div class="person__affil">Mila, U. de Montréal</div>
+  <div class="person__title">Newsletter Lead</div><div class="person__title">Forum Lead</div>
+</a>
+
+<a class="person__item" href="https://asross.github.io/" target="_blank">
+  <div class="person__pic-wrapper">
+    <img class="person__pic" src="images/people/andrew_ross_200x200.jpg">
+  </div>
+  <div class="person__name">Andrew Slavin Ross</div>
+  <div class="person__affil">Harvard University</div>
+  <div class="person__title">Web Lead</div>
+</a>
+
+<a class="person__item" href="https://www.media.mit.edu/people/jaquesn/overview/" target="_blank">
+  <div class="person__pic-wrapper">
+    <img class="person__pic" src="images/people/natashajaques_200x200.jpg">
+  </div>
+  <div class="person__name">Natasha Jaques</div>
+  <div class="person__affil">MIT</div>
+  <div class="person__title">Social Media Lead</div>
+</a>
+</div>
+## Community Leads
+<div class="person__list">
+<a class="person__item" href="https://priyadonti.com/" target="_blank">
+  <div class="person__pic-wrapper">
+    <img class="person__pic" src="images/people/priyadonti_200x200.jpg">
+  </div>
+  <div class="person__name">Priya L. Donti</div>
+  <div class="person__affil">Carnegie Mellon</div>
+  <div class="person__title">Power Sector</div>
+</a>
+
+<a class="person__item" href="https://epg.ethz.ch/people/senior-researchers/dr--lynn-kaack.html" target="_blank">
+  <div class="person__pic-wrapper">
+    <img class="person__pic" src="images/people/lynnkaack_200x200.jpg">
+  </div>
+  <div class="person__name">Lynn H. Kaack</div>
+  <div class="person__affil">ETH Zürich</div>
+  <div class="person__title">Public Sector and International Organizations</div>
+</a>
+
+<a class="person__item" href="http://www.kochanski.org/kelly/" target="_blank">
+  <div class="person__pic-wrapper">
+    <img class="person__pic" src="images/people/kellykochanski_200x200.jpg">
+  </div>
+  <div class="person__name">Kelly Kochanski</div>
+  <div class="person__affil">CU Boulder</div>
+  <div class="person__title">Climate and Earth Sciences</div>
+</a>
+
+<a class="person__item" href="https://www.mcc-berlin.net/en/about/team/milojevic-dupont-nikola.html" target="_blank">
+  <div class="person__pic-wrapper">
+    <img class="person__pic" src="images/people/nikolamilojevicdupont_200x200.jpg">
+  </div>
+  <div class="person__name">Nikola Milojevic-Dupont</div>
+  <div class="person__affil">MCC Berlin, TU Berlin</div>
+  <div class="person__title">Buildings and Transportation</div>
 </a>
 </div>
 ## Advisors
@@ -145,7 +158,7 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
   </div>
   <div class="person__name">Yoshua Bengio</div>
   <div class="person__affil">Mila, U. de Montréal</div>
-  <div class="person__title"></div>
+  
 </a>
 
 <a class="person__item" href="https://www.microsoft.com/en-us/research/people/jchayes/" target="_blank">
@@ -154,7 +167,7 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
   </div>
   <div class="person__name">Jennifer Chayes</div>
   <div class="person__affil">Microsoft Research</div>
-  <div class="person__title"></div>
+  
 </a>
 
 <a class="person__item" href="https://www.mcc-berlin.net/en/about/team/creutzig-felix.html" target="_blank">
@@ -163,7 +176,7 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
   </div>
   <div class="person__name">Felix Creutzig</div>
   <div class="person__affil">MCC Berlin, TU Berlin</div>
-  <div class="person__title"></div>
+  
 </a>
 
 <a class="person__item" href="https://ai.google/research/people/JohnPlatt" target="_blank">
@@ -172,7 +185,7 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
   </div>
   <div class="person__name">John C. Platt</div>
   <div class="person__affil">Google AI</div>
-  <div class="person__title"></div>
+  
 </a>
 
 <a class="person__item" href="https://deepmind.com/" target="_blank">
@@ -181,7 +194,7 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
   </div>
   <div class="person__name">Demis Hassabis</div>
   <div class="person__affil">DeepMind</div>
-  <div class="person__title"></div>
+  
 </a>
 
 <a class="person__item" href="https://www.andrewng.org/" target="_blank">
@@ -190,7 +203,7 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
   </div>
   <div class="person__name">Andrew Y. Ng</div>
   <div class="person__affil">Stanford University</div>
-  <div class="person__title"></div>
+  
 </a>
 
 <a class="person__item" href="https://www.cs.cornell.edu/gomes/" target="_blank">
@@ -199,7 +212,7 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
   </div>
   <div class="person__name">Carla Gomes</div>
   <div class="person__affil">Cornell University</div>
-  <div class="person__title"></div>
+  
 </a>
 
 <a class="person__item" href="http://koerding.com/" target="_blank">
@@ -208,7 +221,7 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
   </div>
   <div class="person__name">Konrad P. Körding</div>
   <div class="person__affil">University of Pennsylvania</div>
-  <div class="person__title"></div>
+  
 </a>
 
 <a class="person__item" href="http://zicokolter.com/" target="_blank">
@@ -217,7 +230,7 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
   </div>
   <div class="person__name">Zico Kolter</div>
   <div class="person__affil">Carnegie Mellon</div>
-  <div class="person__title"></div>
+  
 </a>
 
 <a class="person__item" href="https://ines.stanford.edu" target="_blank">
@@ -226,7 +239,7 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
   </div>
   <div class="person__name">Inês Azevedo</div>
   <div class="person__affil">Stanford University</div>
-  <div class="person__title"></div>
+  
 </a>
 
 <a class="person__item" href="https://epg.ethz.ch/people/group-head/prof--dr--tobias-schmidt.html" target="_blank">
@@ -235,7 +248,7 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
   </div>
   <div class="person__name">Tobias Schmidt</div>
   <div class="person__affil">ETH Zürich</div>
-  <div class="person__title"></div>
+  
 </a>
 
 <a class="person__item" href="https://www.eye-on.ai" target="_blank">
@@ -244,7 +257,7 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
   </div>
   <div class="person__name">Craig Smith</div>
   <div class="person__affil">Eye on AI</div>
-  <div class="person__title"></div>
+  
 </a>
 </div>
 

--- a/about.md
+++ b/about.md
@@ -56,6 +56,15 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
 </div>
 ## Content Committee
 <div class="person__list">
+<a class="person__item" href="https://mila.quebec/en/person/kris-sankaran/" target="_blank">
+  <div class="person__pic-wrapper">
+    <img class="person__pic" src="images/people/krissankaran_200x200.jpg">
+  </div>
+  <div class="person__name">Kris Sankaran</div>
+  <div class="person__affil">Mila, U. de Montréal</div>
+  
+</a>
+
 <a class="person__item" href="https://www.sashaluccioni.com/" target="_blank">
   <div class="person__pic-wrapper">
     <img class="person__pic" src="images/people/sashaluccioni_200x200.jpg">

--- a/generate_people_html.rb
+++ b/generate_people_html.rb
@@ -5,10 +5,17 @@ require 'json'
 
 people = JSON.parse(File.read('people.json'))
 
-steering = people.select { |p| p['committees'].include? 'steering' }
-advisory = people.select { |p| p['committees'].include? 'advisory' }
+committees = [
+  'CCAI Chairs',
+  'Content Committee',
+  'Communications Committee',
+  'Community Leads',
+  'Advisors'
+].each_with_object({}) do |comm, h|
+  h[comm] = people.select{|p| p['committees'].keys.include?(comm) }
+end
 
-def to_html(p)
+def to_html(p, committee)
   <<-HTML
 <a class="person__item" href="#{p['website_url']}" target="_blank">
   <div class="person__pic-wrapper">
@@ -16,7 +23,7 @@ def to_html(p)
   </div>
   <div class="person__name">#{p['name']}</div>
   <div class="person__affil">#{p['affiliation']}</div>
-  <div class="person__title">#{p['title']}</div>
+  #{p['committees'].fetch(committee, []).map{|role| %{<div class="person__title">#{role}</div>}}.join}
 </a>
   HTML
 end
@@ -49,23 +56,13 @@ To empower work that meaningfully addresses the climate crisis and is well-serve
 * To promote discourse about best practices regarding the use of machine learning in climate change domains.
 
 # People
-
-## Steering Committee
-
-<div class="person__list">
 HTML
-
-puts steering.map { |p| to_html(p) }.join("\n")
-
-puts <<-HTML
-</div>
-## Advisors
-<div class="person__list">
-HTML
-
-puts advisory.map { |p| to_html(p) }.join("\n")
-
-puts "</div>"
+committees.each do |committee, members|
+  puts "## #{committee}"
+  puts %{<div class="person__list">}
+  puts members.map { |p| to_html(p, committee) }.join("\n")
+  puts %{</div>}
+end
 
 puts <<-HTML
 

--- a/people.json
+++ b/people.json
@@ -39,7 +39,8 @@
       "Communications Committee": [
         "Newsletter Lead",
         "Forum Lead"
-      ]
+      ],
+      "Content Committee": []
     }
   },
   {

--- a/people.json
+++ b/people.json
@@ -5,7 +5,7 @@
     "name": "David Rolnick",
     "affiliation": "University of Pennsylvania",
     "title": "Chair",
-    "committees": ["steering"]
+    "committees": { "CCAI Chairs": [] }
   },
   {
     "website_url": "https://priyadonti.com/",
@@ -13,7 +13,10 @@
     "name": "Priya L. Donti",
     "affiliation": "Carnegie Mellon",
     "title": "Chair",
-    "committees": ["steering"]
+    "committees": {
+      "CCAI Chairs": [],
+      "Community Leads": ["Power Sector"]
+    }
   },
   {
     "website_url": "https://epg.ethz.ch/people/senior-researchers/dr--lynn-kaack.html",
@@ -21,7 +24,10 @@
     "name": "Lynn H. Kaack",
     "affiliation": "ETH Zürich",
     "title": "Chair",
-    "committees": ["steering"]
+    "committees": {
+      "CCAI Chairs": [],
+      "Community Leads": ["Public Sector and International Organizations"]
+    }
   },
   {
     "website_url": "https://mila.quebec/en/person/kris-sankaran/",
@@ -29,7 +35,12 @@
     "name": "Kris Sankaran",
     "title": "Partnerships",
     "affiliation": "Mila, U. de Montréal",
-    "committees": ["steering"]
+    "committees": {
+      "Communications Committee": [
+        "Newsletter Lead",
+        "Forum Lead"
+      ]
+    }
   },
   {
     "website_url": "https://www.sashaluccioni.com/",
@@ -37,7 +48,9 @@
     "name": "Sasha Luccioni",
     "title": "Partnerships",
     "affiliation": "Mila, U. de Montréal",
-    "committees": ["steering"]
+    "committees": {
+      "Content Committee": ["Committee Chair"]
+    }
   },
   {
     "website_url": "https://asross.github.io/",
@@ -45,132 +58,144 @@
     "name": "Andrew Slavin Ross",
     "title": "Website",
     "affiliation": "Harvard University",
-    "committees": ["steering"]
+    "committees": {
+      "Communications Committee": ["Web Lead"]
+    }
   },
   {
     "website_url": "http://www.kochanski.org/kelly/",
     "image_url": "images/people/kellykochanski.jpg",
     "name": "Kelly Kochanski",
     "affiliation": "CU Boulder",
-    "committees": ["steering"]
+    "committees": {
+      "Community Leads": ["Climate and Earth Sciences"]
+    }
   },
   {
     "website_url": "https://scholar.google.com/citations?user=71a2-WMAAAAJ&hl=en",
     "image_url": "images/people/Alexandre_Lacoste.jpg",
     "name": "Alexandre Lacoste",
     "affiliation": "Element AI",
-    "committees": ["steering"]
+    "committees": {
+      "Content Committee": ["Datasets Lead"]
+    }
   },
   {
     "website_url": "https://www.mcc-berlin.net/en/about/team/milojevic-dupont-nikola.html",
     "image_url": "images/people/nikolamilojevicdupont.jpg",
     "name": "Nikola Milojevic-Dupont",
     "affiliation": "MCC Berlin, TU Berlin",
-    "committees": ["steering"]
+    "committees": {
+      "Community Leads": ["Buildings and Transportation"]
+    }
   },
   {
     "website_url": "https://www.media.mit.edu/people/jaquesn/overview/",
     "image_url": "images/people/natashajaques.jpeg",
     "name": "Natasha Jaques",
     "affiliation": "MIT",
-    "committees": ["steering"]
+    "committees": {
+      "Communications Committee": ["Social Media Lead"]
+    }
   },
   {
     "website_url": "http://www.teganmaharaj.com",
     "image_url": "images/people/teganmaharaj.png",
     "name": "Tegan Maharaj",
     "affiliation": "Mila, Polytechnique Montréal",
-    "committees": ["steering"]
+    "committees": {}
   },
   {
     "website_url": "https://www.evansherwin.com/",
     "image_url": "images/people/evansherwin.png",
     "name": "Evan D. Sherwin",
     "affiliation": "Stanford University",
-    "committees": ["steering"]
+    "committees": {
+      "Content Committee": ["Meetups Lead"]
+    }
   },
   {
     "website_url": "https://mila.quebec/en/yoshua-bengio/",
     "image_url": "images/people/yb.jpg",
     "name": "Yoshua Bengio",
     "affiliation": "Mila, U. de Montréal",
-    "committees": ["advisory"]
+    "committees": { "Advisors": [] }
   },
   {
     "website_url": "https://www.microsoft.com/en-us/research/people/jchayes/",
     "image_url": "images/people/jenniferchayes.jpg",
     "name": "Jennifer Chayes",
     "affiliation": "Microsoft Research",
-    "committees": ["advisory"]
+    "committees": { "Advisors": [] }
   },
   {
     "website_url": "https://www.mcc-berlin.net/en/about/team/creutzig-felix.html",
     "image_url": "images/people/felixcreuzig.jpg",
     "name": "Felix Creutzig",
     "affiliation": "MCC Berlin, TU Berlin",
-    "committees": ["advisory"]
+    "committees": { "Advisors": [] }
   },
   {
     "website_url": "https://ai.google/research/people/JohnPlatt",
     "image_url": "images/people/johnplatt.jpeg",
     "name": "John C. Platt",
     "affiliation": "Google AI",
-    "committees": ["advisory"]
+    "committees": { "Advisors": [] }
   },
   {
     "website_url": "https://deepmind.com/",
     "image_url": "images/people/Demis_Hassabis.jpg",
     "name": "Demis Hassabis",
     "affiliation": "DeepMind",
-    "committees": ["advisory"]
+    "committees": { "Advisors": [] }
   },
   {
     "website_url": "https://www.andrewng.org/",
     "image_url": "images/people/andrewng.jpg",
     "name": "Andrew Y. Ng",
     "affiliation": "Stanford University",
-    "committees": ["advisory"]
+    "committees": { "Advisors": [] }
   },
   {
     "website_url": "https://www.cs.cornell.edu/gomes/",
     "image_url": "images/people/carlagomes.jpg",
     "name": "Carla Gomes",
     "affiliation": "Cornell University",
-    "committees": ["advisory"]
+    "committees": { "Advisors": [] }
   },
   {
     "website_url": "http://koerding.com/",
     "image_url": "images/people/konradkording.jpg",
     "name": "Konrad P. Körding",
     "affiliation": "University of Pennsylvania",
-    "committees": ["advisory"]
+    "committees": { "Advisors": [] }
   },
   {
     "name": "Zico Kolter",
     "website_url":"http://zicokolter.com/",
     "image_url": "images/people/zicokolter.jpg",
     "affiliation": "Carnegie Mellon",
-    "committees": ["advisory"]
+    "committees": { "Advisors": [] }
   },
   {
     "name": "Inês Azevedo",
     "website_url": "https://ines.stanford.edu",
     "image_url": "images/people/inesazevedo.jpg",
     "affiliation": "Stanford University",
-    "committees": ["advisory"]
+    "committees": { "Advisors": [] }
   },
   {
     "name": "Tobias Schmidt",
     "website_url": "https://epg.ethz.ch/people/group-head/prof--dr--tobias-schmidt.html",
     "image_url": "images/people/tobiasschmidt.jpg",
     "affiliation": "ETH Zürich",
-    "committees": ["advisory"]
+    "committees": { "Advisors": [] }
   },
   {
     "website_url": "https://www.eye-on.ai",
     "image_url": "images/people/craigsmith.jpg",
     "name": "Craig Smith",
     "affiliation": "Eye on AI",
-    "committees": ["advisory"]
+    "committees": { "Advisors": [] }
   }
 ]


### PR DESCRIPTION
In this version of the people page, we group people by committee. **Note**: this leaves us without a good place to put steering committee members without roles. Maybe we add some kind of "at large" section?

![image](https://user-images.githubusercontent.com/1022564/79053424-3aba6500-7c0b-11ea-9b24-9b2551e3db68.png)
![image](https://user-images.githubusercontent.com/1022564/79053430-49a11780-7c0b-11ea-83ca-ef54712fdccc.png)
![image](https://user-images.githubusercontent.com/1022564/79053434-5160bc00-7c0b-11ea-9cbf-c8dca4200da4.png)
![image](https://user-images.githubusercontent.com/1022564/79053438-5887ca00-7c0b-11ea-844d-8770e90e753b.png)
