### PR TITLE
Automatically add carousel items for the next upcoming & last recorded webinars

### DIFF
--- a/_data/carousels.yml
+++ b/_data/carousels.yml
@@ -2,9 +2,6 @@
   entries:
     - title: Attend a CCAI virtual happy hour (held fortnightly)
       url: /events/happy_hour
-    - title: Attend our next webinar on March 19
-      image: /images/webinar_equity_02-2021.png
-      url: /webinars
     - title: Check out the CCAI community events calendar
       image: /images/core_team_zoom.png
       url: /community-events

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -519,6 +519,10 @@ td {
   margin-left: -1px;
 }
 
+.slick-initialized .slick-cloned:last-child {
+  margin-left: -1px;
+}
+
 .carousel__background, .carousel__link {
   position: absolute;
   height: 50%;

--- a/index.html
+++ b/index.html
@@ -48,34 +48,83 @@ section {
   margin-bottom: 2rem;
 }
 </style>
+
+<script src="https://cdn.jsdelivr.net/npm/luxon@1.23.0/build/global/luxon.min.js"></script>
 <script>
-$(document).ready(function(){
-   $('.carousel').slick({
-       slidesToShow: 4,
-       slidesToScroll: 4,
-       responsive: [
-        {
-          breakpoint: 768,
-          settings: {
-            slidesToShow: 3,
-            slidesToScroll: 1
-          }
-        },
-        {
-          breakpoint: 624,
-          settings: {
-            slidesToShow: 2,
-            slidesToScroll: 1
-          }
-        },
-        {
-          breakpoint: 480,
-          settings: {
-            slidesToShow: 1,
-            slidesToScroll: 1
-          }
+$(document).ready(() => {
+    const webinars = {{ site.data.webinars | sort: "date" | reverse | jsonify }};
+    const DateTime = luxon.DateTime;
+    const today = DateTime.local().startOf('day');
+
+    let nextUpcoming;
+    let lastRecorded;
+
+    for (let i = 0; i < webinars.length; i++) {
+        webinars[i].date = DateTime.fromISO(webinars[i].date);
+    }
+
+    for (let i = 0; i < webinars.length; i++) {
+        const w = webinars[i];
+
+        if (w.date >= today) {
+            if (!nextUpcoming || w.date < nextUpcoming.date) {
+              nextUpcoming = w;
+            }
+        } else if (w.recording_link) {
+            if (!lastRecorded || w.date > lastRecorded.date) {
+              lastRecorded = w;
+            }
         }
-      ]
-   });
+    }
+
+    if (nextUpcoming) {
+      const $events = $('section:contains("News and events")').find('.carousel');
+      const image = nextUpcoming.image || "/images/full_light_earth_lowres.jpeg";
+      $events.prepend(`<div class='carousel__item'>
+        <div class='carousel__background' style='background-image: url("${image}")'></div>
+        <a class='carousel__link' href='/webinars'>
+          Attend our next webinar on ${nextUpcoming.date.toLocaleString({ month: 'long', day: 'numeric' })}
+        </a>
+      </div>`);
+    }
+
+    if (lastRecorded) {
+      const $content = $('section:contains("Featured content")').find('.carousel');
+      const image = lastRecorded.image || "/images/full_light_earth_lowres.jpeg";
+      $content.prepend(`<div class='carousel__item'>
+        <div class='carousel__background' style='background-image: url("${image}")'></div>
+        <a class='carousel__link' href='${lastRecorded.recording_link}' target='_blank'>
+          View our last webinar: ${lastRecorded.title}
+        </a>
+      </div>`);
+    }
+
+    $('.carousel').slick({
+        slidesToShow: 4,
+        slidesToScroll: 4,
+        responsive: [
+            {
+                breakpoint: 768,
+                settings: {
+                    slidesToShow: 3,
+                    slidesToScroll: 1
+                  }
+              },
+            {
+                breakpoint: 624,
+                settings: {
+                    slidesToShow: 2,
+                    slidesToScroll: 1
+                  }
+              },
+            {
+                breakpoint: 480,
+                settings: {
+                    slidesToShow: 1,
+                    slidesToScroll: 1
+                  }
+              }
+          ]
+      });
 });
 </script>

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@ $(document).ready(() => {
       $events.prepend(`<div class='carousel__item'>
         <div class='carousel__background' style='background-image: url("${image}")'></div>
         <a class='carousel__link' href='/webinars'>
-          Attend our next webinar on ${nextUpcoming.date.toLocaleString({ month: 'long', day: 'numeric' })}
+          Attend our next webinar on ${nextUpcoming.date.toLocaleString({ month: 'long', day: 'numeric' })}: "${nextUpcoming.title}"
         </a>
       </div>`);
     }
@@ -94,7 +94,7 @@ $(document).ready(() => {
       $content.prepend(`<div class='carousel__item'>
         <div class='carousel__background' style='background-image: url("${image}")'></div>
         <a class='carousel__link' href='${lastRecorded.recording_link}' target='_blank'>
-          View our last webinar: ${lastRecorded.title}
+          View our recent webinar: \"${lastRecorded.title}\"
         </a>
       </div>`);
     }

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@ $(document).ready(() => {
       $events.prepend(`<div class='carousel__item'>
         <div class='carousel__background' style='background-image: url("${image}")'></div>
         <a class='carousel__link' href='/webinars'>
-          Attend our next webinar on ${nextUpcoming.date.toLocaleString({ month: 'long', day: 'numeric' })}: "${nextUpcoming.title}"
+          Attend our webinar on ${nextUpcoming.date.toLocaleString({ month: 'long', day: 'numeric' })}: "${nextUpcoming.title}"
         </a>
       </div>`);
     }


### PR DESCRIPTION
Note: there's some ambiguity about where in the carousel order to place the webinar cards. For now, I've gone with the first card (since first & last are the least code), but we could change to, e.g., the second card if need be.

![image](https://user-images.githubusercontent.com/1022564/107854626-18751300-6deb-11eb-8c90-83a4617c27bd.png)
