### PR TITLE
Create coc.md

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -71,6 +71,9 @@
                <a class="navbar-item" href="/about#press">
                 Press
               </a>
+               <a class="navbar-item" href="/code_of_conduct">
+                Community Guidelines
+              </a>
             </div>
           </div>
 

--- a/coc.md
+++ b/coc.md
@@ -1,0 +1,72 @@
+# Community Guidelines
+
+The CCAI community guidelines outline operational standards and expected behaviour throughout all CCAI activities. CCAI values the ideals of open exchange of ideas, the freedom of thought and expression, and respectful science based debate. This requires a community and an environment that recognizes and respects the inherent dignity and worth of every person.
+
+As such, these community guidelines apply to all CCAI activities, including but not limited to:
+* All internal organizational activities. 
+* External events organized by, hosted by, or run in collaboration with CCAI.
+* All communications, media items, and other public outreach published by or through CCAI channels, such as the CCAI website or social media.
+
+All CCAI volunteers as well as participants, speakers, mentors, mentees, panelists, area chairs, reviewers, sponsors, contractors, organizers, and participants at CCAI-affiliated activities as suggested above are expected to comply with this Code of Conduct (CoC).
+
+## Responsibilities & Expected Behavior
+
+Volunteers and community members alike, as outlined above, should help cultivate an environment for productive, creative exchange by following these guidelines. In particular, our community is built on the principles of intellectual diversity and humility, constructive discussion, and scientific integrity. This also includes a set of ground rules for interactions between community members interacting on CCAI platforms or in the context of CCAI organized or affiliated events:
+* The CCAI community encourages an overall warm and welcoming atmosphere. Treat your fellow community members politely and respectfully.
+* Respect the diverse background of CCAI community members. Remember that others might not share your jargon, may be unfamiliar with what you think is common knowledge, and may not speak English (or another language being used for communication) as a first language. 
+* We value honesty and respect for the ownership of ideas. Do not post materials that belong to someone else without their permission, do not publicly share private individuals’ information, and do not violate intellectual property laws. It is important that we are able to trust one another – do not misrepresent your or others’ work, and be sure to properly attribute ideas if sharing them elsewhere.
+
+## Unacceptable Behavior
+
+CCAI is dedicated to fostering an environment free from harassment, bullying, discrimination, and retaliation. This includes offensive comments related to sex, gender identity and expression, sexual orientation, nationality, race, ethnicity, religion (or lack thereof), age, disability, physical appearance, body size, technology choices, education level, socioeconomic status, or any other personal characteristics, as well as further actions or considerations made unlawful by national or local laws, ordinances, or regulations.
+
+Inappropriate or unprofessional behavior will not be tolerated in either physical or virtual settings This includes bullying, intimidation, personal attacks, harassment, sustained disruption of talks or other events, sexual harassment, stalking, following, harassing photography or recording, inappropriate physical contact, unwelcome sexual attention, public vulgar exchanges, derogatory name-calling, or diminutive characterizations, all of which are unwelcome in this community. Advocating for, or encouraging, any of the above behaviour, is also considered harassment. 
+
+No use of images, activities, or other materials that are of a sexual, racial, or otherwise offensive nature that may create an inappropriate or toxic environment is permitted. Disorderly, boisterous, or disruptive conduct including but not limited to fighting, coercion, theft, damage to property, or any mistreatment towards other individuals is not tolerated. Scientific misconduct—including but not limited to fabrication, falsification, or plagiarism of research or ideas in written or spoken form—is prohibited.
+
+## Reporting
+
+If you have concerns related to your participation or interaction at a CCAI activity, observe someone else’s difficulties, or have any other concerns you wish to share, you can make a report: 
+
+* At any time[^1]:
+	By email to reporting@climatechange.ai (monitored by core team members). If you do not want a specific core team member to access your report, please do not provide details in your initial email and instead request that we reach out directly to you (you may specify a subset of core team members you are comfortable replying directly to you). For anonymous emails, you may use a temporary email service such as [Dropmail](https://dropmail.me/en/).
+* During an event:
+	In-person to organizers, or any CCAI-affiliated event volunteer. They will then direct you to the designated responder(s) for that event. 
+
+There is no deadline by which to make a report. 
+
+If the person receiving your report is not the designated responder for that event, they will direct you to a designated responder and/or provide you immediate relevant help and assist you to feel safe for the duration of the activity. Designated responders will follow CCAI procedures to respond to and investigate your report.
+
+## Enforcement
+
+Any participant asked by any member of the community to stop unacceptable behavior is expected to comply immediately. A response of “just joking” will not be accepted; behavior can be harassing without an intent to offend. 
+
+If a participant engages in behaviour that violates these community guidelines, CCAI retains the right to take any action deemed appropriate, including but not limited to: 
+* Formal or informal private warnings
+* Formal public censure
+* Barring or limiting continued attendance and participation, including but not limited to expulsion from the relevant event
+* Barring from participating in or deriving benefits from future CCAI activities
+* Dismissal from current CCAI affiliated roles, e.g. leadership, organizing, mentoring, volunteering, etc.
+* Exclusion from future CCAI opportunities and affiliated roles, e.g. leadership, organizing, volunteering, speaking, reviewing, sponsoring, mentoring, etc.
+* Reporting the incident to the offender’s local institution or funding agencies
+* Reporting the incident to local law enforcement 
+
+Interim measures may be taken, as appropriate, at the time a complaint is made and while the investigation is ongoing. We will not discipline, discriminate against or retaliate against, or tolerate any discrimination or retaliation by any other person against any person who in good faith reports a violation or suspected violation of these community guidelines. The same disciplinary actions may be taken toward any individual who engages in retaliation or who knowingly makes a false allegation of harassment. If action is taken, an appeal may be made.
+
+## Investigation and Appeal Process
+
+Reports of violations will be handled at the discretion of the responsible CCAI Core Team members, who will investigate reports and bring the issue to resolution. The responsible CCAI Core Team members will be selected from a subset of the Core Team consisting of those who have completed the necessary training.  At the same time, at least one of the subset of trained Core Team members will be designated as the arbitrator in case of an appeals process. The designated arbitrator will refrain from participating in the initial investigation and resolution process. Those on the CCAI Core Team whose ability to exert discretion is compromised by a conflict of interest will be asked to step back from the investigation and resolution process. 
+
+Reports made during an event will be responded to within 24 hours; reports made at other times will be responded to in less than five weeks. All reports will be handled as confidentially as possible and information will be disclosed only as it is necessary to complete the investigation and bring it to resolution. If you want to make a report on behalf of another person, you may do so; however we will try to contact that person and only proceed with the investigation if they consent to the investigation. There may be situations (such as those involving Title IX issues in the United States and venue- or employer-specific policies) where the member of the CCAI Core Team informed of the violation will be under an obligation to file a report with another individual or organization outside of CCAI. 
+
+If action is taken, an appeal may be made by submitting a written statement articulating the reasons behind the dispute of the initial resolution. The previously designated arbitrator will review the investigation proceedings, resolution reached, and appeals statement. At their discretion, the arbitrator may conduct additional investigation and will be responsible for bringing the issue to final resolution by either upholding the initial resolution or modifying it as deemed necessary.  An appeals process will only be provided to actions taken in regards to a CCAI affiliated activity - CCAI can not appeal reports or resolutions made by organizations outside of CCAI.
+
+## Regular Review 
+
+We welcome feedback in any form on these community guidelines; If you would like to reach out, please write an email to info@climatechange.ai or reporting@climatechange.ai.
+
+## Acknowledgments
+
+This community guidelines policy was written by adapting the wording and structure from other policies and codes of conduct, first and foremost by [WiML](https://wimlworkshop.org/conduct/) but also by [Geek Feminism Wiki](https://geekfeminism.wikia.org/wiki/Conference_anti-harassment/Policy), [NeurIPS](https://nips.cc/public/CodeOfConduct), [ACM](https://www.acm.org/about-acm/policy-against-harassment), [Montreal AI Symposium](https://montrealaisymposium.wordpress.com/code-of-conduct/), [Deep Learning Indaba](https://deeplearningindaba.com/mentorship/code-of-ethics-and-conduct/), and [CodePath](https://codepath.org/conduct/volunteer).
+
+[^1]: For CCAI core team members, please contact one of the ombudspeople, Lauren or Andrew.

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -28,7 +28,7 @@ No use of images, activities, or other materials that are of a sexual, racial, o
 
 If you have concerns related to your participation or interaction at a CCAI activity, observe someone else’s difficulties, or have any other concerns you wish to share, you can make a report: 
 
-* At any time[^1]:
+* At any time¹:
 	By email to reporting@climatechange.ai (monitored by core team members). If you do not want a specific core team member to access your report, please do not provide details in your initial email and instead request that we reach out directly to you (you may specify a subset of core team members you are comfortable replying directly to you). For anonymous emails, you may use a temporary email service such as [Dropmail](https://dropmail.me/en/).
 * During an event:
 	In-person to organizers, or any CCAI-affiliated event volunteer. They will then direct you to the designated responder(s) for that event. 
@@ -69,4 +69,6 @@ We welcome feedback in any form on these community guidelines; If you would like
 
 This community guidelines policy was written by adapting the wording and structure from other policies and codes of conduct, first and foremost by [WiML](https://wimlworkshop.org/conduct/) but also by [Geek Feminism Wiki](https://geekfeminism.wikia.org/wiki/Conference_anti-harassment/Policy), [NeurIPS](https://nips.cc/public/CodeOfConduct), [ACM](https://www.acm.org/about-acm/policy-against-harassment), [Montreal AI Symposium](https://montrealaisymposium.wordpress.com/code-of-conduct/), [Deep Learning Indaba](https://deeplearningindaba.com/mentorship/code-of-ethics-and-conduct/), and [CodePath](https://codepath.org/conduct/volunteer).
 
-[^1]: For CCAI core team members, please contact one of the ombudspeople, Lauren or Andrew.
+___
+
+¹ For CCAI core team members, please contact one of the ombudspeople, Lauren or Andrew.


### PR DESCRIPTION
Adding the Community Guidelines / Code of Conduct to the website. I wrote the markdown file, but it would still need to be added to the menu bar. Priya and I thought it makes most sense to add it under `About -> Community Guidelines`.