### PR TITLE
Implement a sticky subnav for the ICML workshop page

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -25,6 +25,11 @@ $dark: black;
 @import "bulma-scss/form/_all";
 @import "chosen";
 
+:root {
+  --navbar-height-normal: 80px;
+  --navbar-height-mobile: 64px;
+}
+
 .clearfix::after {
   content: "";
   clear: both;
@@ -37,7 +42,7 @@ $dark: black;
 }
 
 body {
-  padding-top: 5rem;
+  padding-top: var(--navbar-height-normal);
 }
 
 .navbar-brand {
@@ -66,15 +71,15 @@ body {
 
 @media screen and (max-width: 1023px) {
  .navbar.is-fixed-top .navbar-menu, .navbar.is-fixed-top-touch .navbar-menu {
-   max-height: calc(100vh - 68px - 2rem);
+   max-height: calc(100vh - var(--navbar-height-mobile) - 2rem);
  }
 
- .navbar-brand h1 {
-   font-size: 1.5rem;
+ .navbar-brand img {
+   max-height: 3rem;
  }
 
  body {
-   padding-top: calc(5rem - 12px);
+   padding-top: var(--navbar-height-mobile);
  }
 }
 
@@ -371,23 +376,13 @@ details {
 
 // Ensure that anchor links don't skip the headers
 @media screen and (min-width: 1024px) {
-  h1:not(.no-anchor-padding)::before,
-  h2:not(.no-anchor-padding)::before,
-  h3:not(.no-anchor-padding)::before {
-    content: "";
-    display: block;
-    height: 80px; /* fixed header height*/
-    margin: -80px 0 0; /* negative fixed header height */
+  h1, h2, h3 {
+    scroll-margin-top: var(--navbar-height-normal);
   }
 }
 @media screen and (max-width: 1023px) {
-  h1:not(.no-anchor-padding)::before,
-  h2:not(.no-anchor-padding)::before,
-  h3:not(.no-anchor-padding)::before {
-    content: "";
-    display: block;
-    height: 68px; /* fixed header height*/
-    margin: -68px 0 0; /* negative fixed header height */
+  h1, h2, h3 {
+    scroll-margin-top: var(--navbar-height-mobile);
   }
 }
 

--- a/events/icml2021.md
+++ b/events/icml2021.md
@@ -10,7 +10,7 @@ og_image_height: 447
 
 <h1>ICML 2021 Workshop <br> Tackling Climate Change with Machine Learning</h1>
 
-<div class='buttons'>
+<div class='buttons' id='sticky-nav'>
   <a class='button' href='#about-the-workshop'>About</a>
   <a class='button' href='#informational-webinar'>Informational Webinar</a>
   <a class='button' href='#call-for-submissions'>Call for Submissions</a>
@@ -217,3 +217,99 @@ Applications are due by **April 28**.
 **Q:** Can I submit work to this workshop if I am also submitting to another ICML 2021 workshop?<br>
 **A:** Yes. We cannot, however, guarantee that you will not be expected to present the material at a time that conflicts with the other workshop.
 
+<!-- Code for sticky subnav -->
+
+<style>
+
+.sticky #sticky-nav {
+  position: fixed;
+  padding-top: 10px;
+  padding-bottom: 5px;
+  padding-right: 1rem;
+  background: white;
+  width: 100%;
+  z-index: 1;
+}
+
+@media screen and (min-width: 1024px) {
+  .sticky #sticky-nav {
+    top: var(--navbar-height-normal);
+  }
+
+  body.sticky {
+    padding-top: calc(var(--navbar-height-normal) + var(--sticky-nav-height));
+  }
+
+  .sticky h1, .sticky h2, .sticky h3 {
+    scroll-margin-top: calc(var(--navbar-height-normal) + var(--sticky-nav-height));
+  }
+}
+
+@media screen and (max-width: 1023px) {
+  .sticky #sticky-nav {
+    top: var(--navbar-height-mobile);
+  }
+
+  body.sticky {
+    padding-top: calc(var(--navbar-height-mobile) + var(--sticky-nav-height));
+  }
+
+  .sticky h1, .sticky h2, .sticky h3 {
+    scroll-margin-top: calc(var(--navbar-height-mobile) + var(--sticky-nav-height));
+  }
+}
+</style>
+
+<script type='text/javascript'>
+
+$(document).ready(() => {
+  const $stickyNav = $('#sticky-nav');
+  const stickyNav = $stickyNav[0];
+  const stickyOffset = stickyNav.offsetTop;
+  const extraPadding = 10; // Extra padding we'll add above the buttons
+  const minScreenWidth = 480; // Below this screen width, scroll normally
+
+  // Compute the body tag's current padding (which is dynamic, but controls
+  // point at which we stick/unstick)
+  function bodyPadding() {
+    return parseFloat(getComputedStyle(document.body, null).getPropertyValue('padding-top').replace('px', ''));
+  }
+
+  function stickNav() {
+    document.documentElement.style.setProperty('--sticky-nav-height', `${$stickyNav.outerHeight()}px`);
+    document.body.classList.add("sticky");
+  }
+
+  function unstickNav() {
+    document.body.classList.remove("sticky");
+  }
+
+  // When we scroll, stick or unstick the nav as necessary
+  $(window).on("scroll wheel resize touchmove", () => {
+    if (window.innerWidth < minScreenWidth) {
+      unstickNav();
+    } else if (window.scrollY > stickyOffset - bodyPadding() - extraPadding) {
+      stickNav();
+    } else {
+      unstickNav();
+    }
+  });
+
+  // Ensure that when linking to elements from the nav (at the top when it's
+  // not sticky), we scroll down to the right place
+  $stickyNav.find('a').on('click', () => {
+    stickNav();
+    return true;
+  });
+
+  // Fix an issue where the sticky nav covers the <h> element when visiting the
+  // anchor link directly from a URL
+  if ($(location.hash).length) {
+    stickNav();
+    setTimeout(() => {
+      $(location.hash)[0].scrollIntoView();
+    }, 1);
+  }
+});
+
+</script>

--- a/webinars.html
+++ b/webinars.html
@@ -44,7 +44,7 @@ $(document).ready(() => {
 
       let s = "<section class='webinar card'>";
 
-      s += `<p>(${dateStr})</p><h3 class='webinar-title no-anchor-padding'>${w.title}</h3>`;
+      s += `<p>(${dateStr})</p><h3 class='webinar-title'>${w.title}</h3>`;
 
       if (w.subtitle) {
         s += `<div class='webinar-subtitle'>${w.subtitle}</div>`;


### PR DESCRIPTION
(note that the gif below uses the old buttons, but I've rebased and it continues to work as before)

![sticky-nav](https://user-images.githubusercontent.com/1022564/115279288-8653f880-a114-11eb-9f48-b2066cc7ccff.gif)
