### PR TITLE
Update ICML dates

### DIFF
--- a/_data/carousels.yml
+++ b/_data/carousels.yml
@@ -1,6 +1,6 @@
 - title: 'News and events'
   entries:
-    - title: "Submit to our ICML 2021 workshop! Informational webinars Apr 23, 27"
+    - title: "Register for our ICML 2021 workshop on July 23!"
       url: /events/icml2021
       image: /images/icml2021_fb_poster.png
     - title: Attend a CCAI virtual happy hour (held fortnightly)

--- a/events.md
+++ b/events.md
@@ -10,7 +10,7 @@ Our events provide opportunities to share work at the intersection of climate ch
 
 ## Workshops
 
-* [ICML 2021](/events/icml2021) -- July 2021, virtual, date TBD
+* [ICML 2021](/events/icml2021) -- July 23, 2021, virtual
 * [NeurIPS 2020](/events/neurips2020) -- December 11, 2020, virtual
 * [ICLR 2020](/events/iclr2020) -- April 26, 2020, virtual
 * [AMLD 2020](/events/amld2020) -- Jan 27-28, 2020 in Lausanne, Switzerland

--- a/events/icml2021.md
+++ b/events/icml2021.md
@@ -37,7 +37,7 @@ This workshop is part of the [International Conference on Machine Learning (ICML
 
 ## About the Workshop
 
- - Date: July 23 or 24 (TBD)
+ - Date: July 23
  - Location:  Virtual
  - <strike>Mentorship program application deadline: **April 28, 23:59 AOE**</strike>
  - <strike>Mentor-Mentee match notification: May 01, 23:59 AOE</strike>


### PR DESCRIPTION
According to the [ICML schedule](https://icml.cc/Conferences/2021/Schedule?showEvent=8350), we're slated for July 23rd, so I've updated things accordingly, but feel free to correct if it's still up in the air!