### PR TITLE
Allow for prescheduling carousel changes with “{start,stop}_showing_on”

### DIFF
--- a/_data/carousels.yml
+++ b/_data/carousels.yml
@@ -3,6 +3,12 @@
     - title: "Register for our ICML 2021 workshop on July 23!"
       url: /events/icml2021
       image: /images/icml2021_fb_poster.png
+      stop_showing_on: 2021-07-22
+    - title: "Attend our ICML 2021 workshop on July 23!"
+      url: /events/icml2021
+      image: /images/icml2021_fb_poster.png
+      start_showing_on: 2021-07-22
+      stop_showing_on: 2021-07-24
     - title: Attend a CCAI virtual happy hour (held fortnightly)
       url: /events/happy_hour
     - title: Check out the CCAI community events calendar
@@ -16,6 +22,10 @@
       url: https://www.americansecurityproject.org/climate-and-ai-with-dr-david-rolnick/
 - title: 'Featured content'
   entries:
+    - title: "Browse papers and talks from ICML 2021"
+      url: /events/icml2021
+      image: /images/icml2021_fb_poster.png
+      start_showing_on: 2021-07-24
     - title: View interactive summaries of our climate + ML paper
       image: /images/summaries_teaser.png
       url: /summaries
@@ -27,5 +37,6 @@
     - title: Browse papers and talks from NeurIPS 2020
       image: /images/NeurIPS2020_preview_copy4.png
       url: /events/neurips2020
+      stop_showing_on: 2021-07-24
     - title: Join the conversation on our discussion forum
       url: https://forum.climatechange.ai/

--- a/index.html
+++ b/index.html
@@ -9,32 +9,8 @@ description: Tackling Climate Change with Machine Learning
   <center><i>Catalyzing impactful work at the intersection of climate change and machine learning</i></center>
 </section>
 
-{% for section in site.data.carousels %}
-  <section>
-    <h2>{{ section.title }}</h2>
-
-    <div class='carousel'>
-      {% for e in section.entries %}
-        {% assign image = e.image | default: "/images/full_light_earth_lowres.jpeg" %}
-
-        {% if e.url contains 'http' %}
-          {% assign target = '_blank' %}
-        {% else %}
-          {% assign target = '' %}
-        {% endif %}
-
-        <div class='carousel__item'>
-          <div class='carousel__background' style='background-image: url("{{ image }}")'></div>
-          <a class='carousel__link' href='{{ e.url }}' target='{{ target }}'>
-            <div class='carousel__link-text'>
-              {{ e.title }}
-            </div>
-          </a>
-        </div>
-      {% endfor %}
-    </div>
-  </section>
-{% endfor %}
+<div id='carousels'>
+</div>
 
 <section>
   <h2>Sign up for our newsletter</h2>
@@ -55,6 +31,8 @@ section {
 <script>
 $(document).ready(() => {
     const webinars = {{ site.data.webinars | sort: "date" | reverse | jsonify }};
+    const carousels = {{ site.data.carousels | jsonify }};
+
     const DateTime = luxon.DateTime;
     const today = DateTime.local().startOf('day');
 
@@ -70,39 +48,61 @@ $(document).ready(() => {
 
         if (w.date >= today) {
             if (!nextUpcoming || w.date < nextUpcoming.date) {
-              nextUpcoming = w;
+              nextUpcoming = {
+                date: w.date,
+                image: w.image,
+                title: `Attend our webinar on ${w.date.toLocaleString({ month: 'long', day: 'numeric' })}: "${w.title}"`,
+                url: '/webinars'
+              };
             }
         } else if (w.recording_link) {
             if (!lastRecorded || w.date > lastRecorded.date) {
-              lastRecorded = w;
+              lastRecorded = {
+                date: w.date,
+                image: w.image,
+                title: `View our recent webinar: "${w.title}"`,
+                url: w.recording_link
+              };
             }
         }
     }
 
-    if (nextUpcoming) {
-      const $events = $('section:contains("News and events")').find('.carousel');
-      const image = nextUpcoming.image || "/images/full_light_earth_lowres.jpeg";
-      $events.prepend(`<div class='carousel__item'>
-        <div class='carousel__background' style='background-image: url("${image}")'></div>
-        <a class='carousel__link' href='/webinars'>
-          <div class='carousel__link-text'>
-            Attend our webinar on ${nextUpcoming.date.toLocaleString({ month: 'long', day: 'numeric' })}: "${nextUpcoming.title}"
+    function carouselEntry(entry) {
+        const image = entry.image || '/images/full_light_earth_lowres.jpeg';
+        const target = entry.url.startsWith('http') ? '_blank' : '';
+        return `
+          <div class='carousel__item'>
+            <div class='carousel__background' style='background-image: url("${image}")'></div>
+            <a class='carousel__link' href='${entry.url}' target='${target}'>
+              <div class='carousel__link-text'>${entry.title}</div>
+            </a>
           </div>
-        </a>
-      </div>`);
+        `;
     }
 
-    if (lastRecorded) {
-      const $content = $('section:contains("Featured content")').find('.carousel');
-      const image = lastRecorded.image || "/images/full_light_earth_lowres.jpeg";
-      $content.prepend(`<div class='carousel__item'>
-        <div class='carousel__background' style='background-image: url("${image}")'></div>
-        <a class='carousel__link' href='${lastRecorded.recording_link}' target='_blank'>
-          <div class='carousel__link-text'>
-            View our recent webinar: \"${lastRecorded.title}\"
-          </div>
-        </a>
-      </div>`);
+    for (let carousel of carousels) {
+        const $carousel = $("<div class='carousel'></div>");
+
+        // Add webinars to carousels if present
+        if (nextUpcoming && carousel.title == "News and events")
+            $carousel.append(carouselEntry(nextUpcoming));
+        if (lastRecorded && carousel.title == "Featured content")
+            $carousel.append(carouselEntry(lastRecorded));
+
+        // Add explicitly provided carousel entries
+        for (let entry of carousel.entries) {
+            // But only if they aren't stale / unripe
+            if (entry.start_showing_on && today < DateTime.fromISO(entry.start_showing_on))
+                continue;
+            if (entry.stop_showing_on && today >= DateTime.fromISO(entry.stop_showing_on))
+                continue;
+            $carousel.append(carouselEntry(entry));
+        }
+
+        const $section = $('<section></section>');
+        $section.append(`<h2>${carousel.title}</h2>`);
+        $section.append($carousel);
+        $('#carousels').append($section);
     }
 
     $('.carousel').slick({
@@ -131,6 +131,6 @@ $(document).ready(() => {
                   }
               }
           ]
-      });
+    });
 });
 </script>


### PR DESCRIPTION
With this change, you can add `start_showing_on` and/or `stop_showing_on` dates to each entry of [`_data/carousels.yml`](https://github.com/climatechange-ai/climatechange_ai/blob/master/_data/carousels.yml) (in YYYY-MM-DD format), which will cause them to only be rendered after / up until the corresponding date (in the user's local timezone).

I also included an example set of changes that we might make for our upcoming ICML workshop on July 23rd, where the start of the title of the entry changes from "Register for" to "Attend" on July 22nd, and then after July 24th the whole entry moves from "News and events" down to "Featured content", with a title change to "Browse papers and talks" and replacing the old entry for NeurIPS.

Note that there is potentially a bit of inconsistency here around time zones, since we're determining "today" using the user's local time --- this means that users viewing our site from different locations around the world will see different things. We could potentially change this behavior by allowing a `timezone` parameter to be specified in the `.yml` file (e.g. `'America/New_York'`), and then we could compare the current time to the start of the day in that time zone --- e.g. instead of `today <= DateTime.fromISO(entry.start_showing_on)`, we could do `DateTime.fromISO(entry.start_showing_on).setZone(entry.timezone).startOf('day')`. Let me know if you think we should build in this option!