### PR TITLE
update menu bar, including deprecating resources and calls

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -92,11 +92,11 @@
               <a class="navbar-item" href="/tutorials">
                 Tutorials
               </a>
-              <a class="navbar-item" href="/resources">
+<!--               <a class="navbar-item" href="/resources">
                 Readings and datasets
-              </a>
+              </a> -->
               <a class="navbar-item" href="https://wiki.climatechange.ai/" target="_blank">
-                Wiki&nbsp;<span class='tag is-info'>new!</span>
+                Resource Wiki&nbsp;<span class='tag is-info'>new!</span>
               </a>
             </div>
           </div>
@@ -113,9 +113,12 @@
               <a class="navbar-item" target="_blank" href="https://forum.climatechange.ai/">
                 Forum
               </a>
-              <a class="navbar-item" href="/calls">
-                Calls
+              <a class="navbar-item" href="/community-events">
+                Community events
               </a>
+<!--               <a class="navbar-item" href="/calls">
+                Calls
+              </a> -->
 
             </div>
           </div>
@@ -130,15 +133,6 @@
               <a class="navbar-item" href="/webinars">Webinars</a>
               <a class="navbar-item" href="/events/happy_hour">Happy hours</a>
               <a class="navbar-item" href="/events">Past events</a>
-              <hr class="navbar-divider">
-              <a class="navbar-item" target="_blank" href="/community-events">
-                Community events
-              </a>
-              <!-- <a class="navbar-item" href="/events/iclr2020">ICLR 2020</a>
-              <a class="navbar-item" href="/events/amld2020">AMLD 2020</a>
-              <a class="navbar-item" href="/events/neurips2019">NeurIPS 2019</a>
-              <a class="navbar-item" href="/events/cop25">COP25</a>
-              <a class="navbar-item" href="/events/icml2019">ICML 2019</a> -->
             </div>
           </div>
 

--- a/faq.md
+++ b/faq.md
@@ -14,7 +14,7 @@ redirect_from:
 # Frequently Asked Questions
 
 ### I want to learn more about climate change and machine learning. Where can I start?
-We encourage you to check out our <a href="{{ site.paper_url }}" target="_blank">paper</a>, which provides a detailed guide of ways machine learning can be used to tackle climate change, as well as the accompanying [resources](/resources) and [tutorials](/tutorials) on our website, and our <a href="https://wiki.climatechange.ai" target="_blank">wiki</a>. We also encourage you to explore routes such as setting up a reading group at your institution or via our <a href="{{ site.forum_url }}" target="_blank">discussion forum</a>.
+We encourage you to check out our <a href="{{ site.paper_url }}" target="_blank">paper</a>, which provides a detailed guide of ways machine learning can be used to tackle climate change, as well as the accompanying [tutorials](/tutorials) on our website, and our <a href="https://wiki.climatechange.ai" target="_blank">Wiki</a>. We also encourage you to explore routes such as setting up a reading group at your institution or via our <a href="{{ site.forum_url }}" target="_blank">discussion forum</a>.
 
 ### I’ve read the paper and checked out the resources. What should I do next?
 We encourage you to join the conversations on our <a href="{{ site.forum_url }}" target="_blank">discussion forum</a> and social media channels, sign up for our [newsletter](/newsletter), submit to one of our [workshops](/events), or attend one of our [events](/events) in order to find collaborators. You might also consider organizing or attending informal meetups through our <a href="{{ site.forum_url }}" target="_blank">discussion forum</a> to meet others working in this area.
@@ -23,7 +23,7 @@ We encourage you to join the conversations on our <a href="{{ site.forum_url }}"
 Yes! One of our goals is to connect people working in areas relevant to climate change with experts in machine learning. For some helpful background on AI and machine learning, we encourage you to check out our [tutorial](/tutorials) on machine learning or other online resources such as this <a href="https://www.coursera.org/learn/machine-learning" target="_blank">Coursera course</a>.
 
 ### I don’t know much about climate change. Can I still be involved?
-Yes! One of our goals is to connect people working in machine learning to experts working in areas relevant to climate change. We encourage you to check out our [tutorial](/tutorials) on climate change. For some helpful background readings on climate change and related areas, you can also check out our [resources page](/resources) and our <a href="https://wiki.climatechange.ai" target="_blank">wiki</a>.
+Yes! One of our goals is to connect people working in machine learning to experts working in areas relevant to climate change. We encourage you to check out our [tutorial](/tutorials) on climate change. For some helpful background readings on climate change and related areas, you can also check out our <a href="https://wiki.climatechange.ai" target="_blank">Wiki</a>.
 
 ### I want to take on a project at the intersection of climate change and machine learning. Can you recommend a project for me to work on?
 We encourage you to check out <a href="{{ site.paper_url }}" target="_blank">our paper</a> and [previous events](/events#past-events) for ideas. To discuss project ideas or find collaborators, you can head over to our <a href="{{ site.forum_url }}" target="_blank">discussion forum</a> or join us at one of our [events](/events).

--- a/resources.md
+++ b/resources.md
@@ -3,6 +3,8 @@ title: Climate Change AI - Resources
 description: This page presents some readings, datasets, and tools for the areas outlined in our paper, "Tackling Climate Change with Machine Learning."
 redirect_from:
   - /readings-datasets
+redirect_to:
+  - https://wiki.climatechange.ai/
 ---
 
 # Resources


### PR DESCRIPTION
Update menu bar entries slightly. 

Changes:
- **Changed "Wiki" to "Resource Wiki"** (per @drolnick's suggestion) to make it clearer what it is.
- **Removed "Calls" under "Engage"**, since our remaining call is out of date. (In the future, we may want to make "grants" a separate menu item altogether, to both make it more prominent and because "calls" isn't necessarily clear.)
- **Moved "Community events" from "Events" to "Engage."** Even though these are technically events, we had previously separated them from the rest of the events via a horizontal bar. My thought is that it's probably cleaner to just put this under "engage," since in some ways the community events calendar is more like the forum.
- **Removed "Readings and datasets" under "Learn"** The desired final state of the resources page is to curate a small highlighted set of resources, and have the Wiki be more extensive. However, the resources page is right now in a somewhat intermediate state, so in my opinion is probably best to remove.

The removal of the resources page necessitates a few other changes, also captured in this PR:
- **Redirect of resources page to Wiki:** Anyone who tries to go to /resources will now be redirected to the Wiki.
- **Minor changes to FAQ:** Removing mentions of resources page (Wiki references had already been added there anyway).