### PR TITLE
reduce number of headers on newsletter page

### DIFF
--- a/_includes/newsletter_signup_form.html
+++ b/_includes/newsletter_signup_form.html
@@ -314,5 +314,5 @@
 <!--End mc_embed_signup-->
 
 <p>
-If the sign-up form isn't appearing above this message, you can also sign up <a href='https://climatechange.us3.list-manage.com/subscribe?u=a5463f28627a77a4b2a79e7d0&id=e28537c7a1' target='_blank'>here</a>.
+If the signup form isn't appearing above this message, you can also sign up <a href='https://climatechange.us3.list-manage.com/subscribe?u=a5463f28627a77a4b2a79e7d0&id=e28537c7a1' target='_blank'>here</a>.
 </p>

--- a/newsletter.md
+++ b/newsletter.md
@@ -4,9 +4,7 @@ title: Climate Change AI - Newsletters
 description: Archive of Climate Change AI newsletters
 ---
 
-# Newsletter
-
-## Sign Up
+## Newsletter Signup
 
 {% include newsletter_signup_form.html %}
 


### PR DESCRIPTION
Remove the title "Newsletter" from the top of the page, and instead have two h2's: "Newsletter Signup" and "Archive." This shifts the main content up and, in particular, makes it so the archive is more likely to be seen, without losing any information about what page the user is on. I think the only tradeoff is consistency (other pages have an h1 title), but I think that's okay to lose for the purposes of utility in this case.

![image](https://user-images.githubusercontent.com/3598351/123518634-c2578c80-d674-11eb-9e4b-1daf444ad466.png)
