### PR TITLE
move tutorials into table

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -461,6 +461,20 @@ td {
   }
 }
 
+.tutorial {
+  padding: 1rem;
+}
+
+.tutorial-table {
+  td:first-child {
+    white-space: nowrap;
+  }
+
+  td:last-child {
+    width: 100%;
+  }
+}
+
 .remote-workshop-table {
   td.fill-utc, td.fill-local {
     white-space: nowrap;

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -720,3 +720,18 @@ td {
 .slick-arrow.slick-hidden {
     display: none;
 }
+
+.youtube-embed-wrapper {
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-bottom: 56.25%;
+}
+
+.youtube-embed {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}

--- a/tutorials.md
+++ b/tutorials.md
@@ -6,12 +6,20 @@ description: Tutorials on climate change and machine learning
 
 # Tutorials
 
-Check out our tutorials on [climate change](#climate-change-101) and [machine learning](#machine-learning-101) below!
+Check out our tutorials on climate change and machine learning below!
 
-## Climate Change 101
+<section class='webinar card'>
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/KB4vUk1-yNQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+<h2>Climate Change 101 (<a href="https://www.youtube.com/watch?v=KB4vUk1-yNQ&ab_channel=ClimateChangeAI" target="_blank">direct link</a>) </h2>
 
-## Machine Learning 101
+<iframe width="500" height="281.25" src="https://www.youtube.com/embed/KB4vUk1-yNQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-<iframe width="560" height="315" src="https://www.youtube.com/embed/mc9QG2R-rf4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</section>
+
+<section class='webinar card'>
+
+<h2>Machine Learning 101 (<a href="https://www.youtube.com/watch?v=mc9QG2R-rf4&ab_channel=ClimateChangeAI" target="_blank">direct link</a>) </h2>
+
+<iframe width="500" height="281.25" src="https://www.youtube.com/embed/mc9QG2R-rf4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+</section>

--- a/tutorials.md
+++ b/tutorials.md
@@ -8,7 +8,7 @@ description: Tutorials on climate change and machine learning
 
 Check out our tutorials on climate change and machine learning below!
 
-<section class='webinar card'>
+<section class='tutorial card'>
 
 <h2>Climate Change 101 (<a href="https://www.youtube.com/watch?v=KB4vUk1-yNQ&ab_channel=ClimateChangeAI" target="_blank">direct link</a>) </h2>
 
@@ -18,7 +18,7 @@ Check out our tutorials on climate change and machine learning below!
 
 </section>
 
-<section class='webinar card'>
+<section class='tutorial card'>
 
 <h2>Machine Learning 101 (<a href="https://www.youtube.com/watch?v=mc9QG2R-rf4&ab_channel=ClimateChangeAI" target="_blank">direct link</a>) </h2>
 

--- a/tutorials.md
+++ b/tutorials.md
@@ -8,22 +8,36 @@ description: Tutorials on climate change and machine learning
 
 Check out our tutorials on climate change and machine learning below!
 
+<div class='tutorials'>
 <section class='tutorial card'>
 
 <h2>Climate Change 101 (<a href="https://www.youtube.com/watch?v=KB4vUk1-yNQ&ab_channel=ClimateChangeAI" target="_blank">direct link</a>) </h2>
 
-<center>
-<iframe width="500" height="281.25" src="https://www.youtube.com/embed/KB4vUk1-yNQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</center>
+<div class="youtube-embed-wrapper">
+  <iframe class="youtube-embed"
+    src="https://www.youtube.com/embed/KB4vUk1-yNQ"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen>
+  </iframe>
+</div>
 
 </section>
+
+<br>
 
 <section class='tutorial card'>
 
 <h2>Machine Learning 101 (<a href="https://www.youtube.com/watch?v=mc9QG2R-rf4&ab_channel=ClimateChangeAI" target="_blank">direct link</a>) </h2>
 
-<center>
-<iframe width="500" height="281.25" src="https://www.youtube.com/embed/mc9QG2R-rf4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</center>
+<div class="youtube-embed-wrapper">
+  <iframe class="youtube-embed"
+    src="https://www.youtube.com/embed/mc9QG2R-rf4"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen>
+  </iframe>
+</div>
 
 </section>
+</div>

--- a/tutorials.md
+++ b/tutorials.md
@@ -12,7 +12,9 @@ Check out our tutorials on climate change and machine learning below!
 
 <h2>Climate Change 101 (<a href="https://www.youtube.com/watch?v=KB4vUk1-yNQ&ab_channel=ClimateChangeAI" target="_blank">direct link</a>) </h2>
 
+<center>
 <iframe width="500" height="281.25" src="https://www.youtube.com/embed/KB4vUk1-yNQ" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</center>
 
 </section>
 
@@ -20,6 +22,8 @@ Check out our tutorials on climate change and machine learning below!
 
 <h2>Machine Learning 101 (<a href="https://www.youtube.com/watch?v=mc9QG2R-rf4&ab_channel=ClimateChangeAI" target="_blank">direct link</a>) </h2>
 
+<center>
 <iframe width="500" height="281.25" src="https://www.youtube.com/embed/mc9QG2R-rf4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+</center>
 
 </section>


### PR DESCRIPTION
Mirroring the aesthetic on other parts of the site, putting the tutorials into table cells and adding "direct links" to the videos like we do in the workshop pages.

![image](https://user-images.githubusercontent.com/3598351/123519330-84f4fe00-d678-11eb-994f-5aea94b5bd0a.png)
