### PR TITLE
Reorganize events listings

### DIFF
--- a/events.md
+++ b/events.md
@@ -10,15 +10,15 @@ Our events provide opportunities to share work at the intersection of climate ch
 
 ## Upcoming Events
 
-* [ICML 2021](/events/icml2021) -- July 23, 2021, virtual
+* [ICML 2021](/events/icml2021) workshop -- July 23, 2021, virtual
 * [Webinars](/webinars) -- about once a month, virtual
 * [Happy Hours](/events/happy_hour) -- every two weeks, virtual
 
 ## Past Events
-* [NeurIPS 2020](/events/neurips2020) -- December 11, 2020, virtual
+* [NeurIPS 2020](/events/neurips2020) workshop -- December 11, 2020, virtual
 * [TEDx Countdown](/events/tedx) -- Oct 17, 2020, virtual
-* [ICLR 2020](/events/iclr2020) -- April 26, 2020, virtual
-* [AMLD 2020](/events/amld2020) -- Jan 27-28, 2020 in Lausanne, Switzerland
-* [NeurIPS 2019](/events/neurips2019) -- Dec 14, 2019 in Vancouver, BC, Canada
-* [COP25](/events/cop25) -- Dec 4, 2019 in Madrid, Spain
-* [ICML 2019](/events/icml2019) -- Jun 14, 2019 in Long Beach, CA, USA
+* [ICLR 2020](/events/iclr2020) workshop -- April 26, 2020, virtual
+* [AMLD 2020](/events/amld2020) workshop -- Jan 27-28, 2020 in Lausanne, Switzerland
+* [NeurIPS 2019](/events/neurips2019) workshop -- Dec 14, 2019 in Vancouver, BC, Canada
+* [COP25](/events/cop25) side event -- Dec 4, 2019 in Madrid, Spain
+* [ICML 2019](/events/icml2019) workshop -- Jun 14, 2019 in Long Beach, CA, USA

--- a/events.md
+++ b/events.md
@@ -8,17 +8,17 @@ description: 'Climate Change AI events'
 
 Our events provide opportunities to share work at the intersection of climate change and machine learning, to meet others who care about making a difference in this area, and to build teams across sectors to solve important problems. Check out recordings and abstracts from our events at the links below.
 
-## Workshops
+## Upcoming Events
 
 * [ICML 2021](/events/icml2021) -- July 23, 2021, virtual
+* [Webinars](/webinars) -- about once a month, virtual
+* [Happy Hours](/events/happy_hour) -- every two weeks, virtual
+
+## Past Events
 * [NeurIPS 2020](/events/neurips2020) -- December 11, 2020, virtual
+* [TEDx Countdown](/events/tedx) -- Oct 17, 2020, virtual
 * [ICLR 2020](/events/iclr2020) -- April 26, 2020, virtual
 * [AMLD 2020](/events/amld2020) -- Jan 27-28, 2020 in Lausanne, Switzerland
 * [NeurIPS 2019](/events/neurips2019) -- Dec 14, 2019 in Vancouver, BC, Canada
-* [ICML 2019](/events/icml2019) -- Jun 14, 2019 in Long Beach, CA, USA
-
-## Other Events
-* [Webinars](/webinars)
-* [Happy Hours](/events/happy_hour) -- every two weeks, virtual
-* [TEDx Countdown](/events/tedx) -- Oct 17, 2020, virtual
 * [COP25](/events/cop25) -- Dec 4, 2019 in Madrid, Spain
+* [ICML 2019](/events/icml2019) -- Jun 14, 2019 in Long Beach, CA, USA

--- a/events.md
+++ b/events.md
@@ -11,14 +11,14 @@ Our events provide opportunities to share work at the intersection of climate ch
 ## Upcoming Events
 
 * [ICML 2021](/events/icml2021) workshop -- July 23, 2021, virtual
-* [Webinars](/webinars) -- about once a month, virtual
+* [Webinars](/webinars) -- once a month, virtual
 * [Happy Hours](/events/happy_hour) -- every two weeks, virtual
 
 ## Past Events
 * [NeurIPS 2020](/events/neurips2020) workshop -- December 11, 2020, virtual
 * [TEDx Countdown](/events/tedx) -- Oct 17, 2020, virtual
 * [ICLR 2020](/events/iclr2020) workshop -- April 26, 2020, virtual
-* [AMLD 2020](/events/amld2020) workshop -- Jan 27-28, 2020 in Lausanne, Switzerland
+* [AMLD 2020](/events/amld2020) conference track -- Jan 27-28, 2020 in Lausanne, Switzerland
 * [NeurIPS 2019](/events/neurips2019) workshop -- Dec 14, 2019 in Vancouver, BC, Canada
 * [COP25](/events/cop25) side event -- Dec 4, 2019 in Madrid, Spain
 * [ICML 2019](/events/icml2019) workshop -- Jun 14, 2019 in Long Beach, CA, USA


### PR DESCRIPTION
Reorganized into Upcoming and Past instead of Workshops and Other. Also added a frequency for Webinars.

<img width="702" alt="Screen Shot 2021-06-27 at 5 44 43 PM" src="https://user-images.githubusercontent.com/5883053/123560355-9b31b580-d76f-11eb-9b42-7a08be97fd99.png">
