### PR TITLE
Add option for comment iframe

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -82,6 +82,13 @@ layout: default
 
 <script src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
 
+{% if post.comment_url %}
+    <h2 id='comments'>Comments</h2>
+    <iframe style="border: 1px solid #eee; box-shadow: none; width: 100%; height: 80vh;" src="{{ post.comment_url }}">
+        Loading...
+    </iframe>
+{% endif %}
+
 <script>
 $(document).ready(() => {
     $('.post-author-name').click(ev => {

--- a/_posts/2021-10-28-hello-world.md
+++ b/_posts/2021-10-28-hello-world.md
@@ -7,6 +7,7 @@ image_attribution: "Image by <a href='https://www.flickr.com/photos/wallboat/374
 authors: jesse
 article_type: "Blog admin"
 topical_tags: announcement
+comment_url: https://community.climatechange.ai/c/blog/happy-birthday-to-the-ccai-blog?iframe=true
 ---
 
 CCAI’s [core goals](https://www.climatechange.ai/about) are all about serving our [growing community](https://directory.climatechange.ai/) of researchers and stakeholders who work at the intersection of climate change and AI. To that end, much of what we do is curate and produce content: we publish a [newsletter](https://www.climatechange.ai/newsletter); we run [research workshops](https://www.climatechange.ai/events#past-events) and host [webinars](https://www.climatechange.ai/webinars); we post relevant papers, jobs, and news [on Twitter](https://twitter.com/ClimateChangeAI) and in our [Circle community](https://community.climatechange.ai); we publish [guides](https://www.climatechange.ai/summaries) to working in this space; and so forth.


### PR DESCRIPTION
Allows comment frames to be added if a `comment_url` parameter is included in the post front matter. We could make this more automatic in the future if we decided to follow a naming convention where it's possible to infer the URL of the circle post from the title of the blog post.

<img width="1180" alt="image" src="https://user-images.githubusercontent.com/1022564/145426881-fff2d921-2a7a-4568-a2ae-f22cbcb1d9ec.png">
